### PR TITLE
Fix ticker error handling

### DIFF
--- a/internal/ticker/fetch.go
+++ b/internal/ticker/fetch.go
@@ -40,6 +40,7 @@ func (t *Ticker) Fetch() time.Duration {
 
 	t.mu.Lock()
 	t.last = res
+	t.error = nil
 	t.mu.Unlock()
 
 	nextRead := time.Until(res.Properties.GetNextRead()) + t.config.FetchDelay


### PR DESCRIPTION
## Summary
- clear stored error after a successful fetch so `Last()` doesn't keep returning old errors

## Testing
- `go test ./...` *(fails: Forbidden to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684762f42354832ca1d383b452526502